### PR TITLE
use only one extra bastion tag to avoid creating tuple

### DIFF
--- a/ec2.tf
+++ b/ec2.tf
@@ -27,15 +27,14 @@ EOF
 
 # Cannot use dynamic tags with this resource type
 locals {
-  customTags = [for tag in var.bastion_tags : {
-    key   = tag.value["key"]
-    value = tag.value["value"]
-  }]
-  regularTags = [{
+  tags = {
+    key   = var.bastion_patchGroup_tag.key
+    value = var.bastion_patchGroup_tag.value,
     key   = "Name"
     value = "Bastion Host ${var.bastion_count + 1}"
-  }]
+  }
 }
+
 
 resource "aws_instance" "bastion_hosts" {
   count         = var.bastion_count
@@ -43,7 +42,7 @@ resource "aws_instance" "bastion_hosts" {
   instance_type = var.bastion_instance_type
   subnet_id     = aws_subnet.utility_subnet.id
   key_name      = var.bastion_key_name
-  tags          = concat(local.customTags, local.regularTags)
+  tags          = local.tags
 
   vpc_security_group_ids = [aws_security_group.utility_hosts.id]
 

--- a/variables.tf
+++ b/variables.tf
@@ -68,11 +68,14 @@ variable bastion_key_name {
   description = "The key name for the bastion host without.pem on the end. Make sure you have access to it."
 }
 
-variable "bastion_tags" {
-  default     = []
-  description = "Additional bastion host tags for patch groups and such"
-  type = list(object({
+variable bastion_patchGroup_tag {
+  default = {
+    key   = "PatchGroup"
+    value = "None"
+  }
+  description = "Optional bastion host patch groups tag"
+  type = object({
     key   = string
     value = string
-  }))
+  })
 }


### PR DESCRIPTION
My previous idea of iterating over an array of multiple custom tags created a tuple, this is to prevent that.  The tf docs say 'tags' is looking for a map of type string, but this appears to be how you can build a map with objects in it, looks similar to other examples and passes validate. fingers crossed!