### PR TITLE
add empty bastion role and patch group tag defaulting to none

### DIFF
--- a/ec2.tf
+++ b/ec2.tf
@@ -25,24 +25,23 @@ sudo yum -y update
 EOF
 }
 
-# Cannot use dynamic tags with this resource type
+# Cannot use dynamic tags with aws_instance resource
 locals {
   tags = {
-    key   = var.bastion_patchGroup_tag.key
-    value = var.bastion_patchGroup_tag.value,
-    key   = "Name"
-    value = "Bastion Host ${var.bastion_count + 1}"
+    "Patch Group" = var.bastion_patchGroup_tag.value,
+    Name          = "Bastion Host ${var.bastion_count}"
   }
 }
 
 
 resource "aws_instance" "bastion_hosts" {
-  count         = var.bastion_count
-  ami           = data.aws_ami.ec2_linux.id
-  instance_type = var.bastion_instance_type
-  subnet_id     = aws_subnet.utility_subnet.id
-  key_name      = var.bastion_key_name
-  tags          = local.tags
+  count                = var.bastion_count
+  ami                  = data.aws_ami.ec2_linux.id
+  instance_type        = var.bastion_instance_type
+  subnet_id            = aws_subnet.utility_subnet.id
+  iam_instance_profile = aws_iam_instance_profile.bastion_profile.id
+  key_name             = var.bastion_key_name
+  tags                 = local.tags
 
   vpc_security_group_ids = [aws_security_group.utility_hosts.id]
 

--- a/iam.tf
+++ b/iam.tf
@@ -1,0 +1,24 @@
+# Creates an empty role so that policies can be attached as needed
+resource "aws_iam_instance_profile" "bastion_profile" {
+  name = "bastion-profile"
+  role = aws_iam_role.bastion_role.name
+}
+
+resource "aws_iam_role" "bastion_role" {
+  name = "RoleForBastion"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}

--- a/output.tf
+++ b/output.tf
@@ -77,3 +77,8 @@ output "private_route_table_id" {
   value       = aws_route_table.private_route_table.id
   description = "The ID of the private route table."
 }
+
+output "bastion_instance_role_name" {
+  value       = aws_iam_role.bastion_role.name
+  description = "The ID for the role that grants the bastion instance AWS permissions."
+}

--- a/variables.tf
+++ b/variables.tf
@@ -68,12 +68,13 @@ variable bastion_key_name {
   description = "The key name for the bastion host without.pem on the end. Make sure you have access to it."
 }
 
+# Patch group tag for patching with ssm. Defaults to none.
 variable bastion_patchGroup_tag {
   default = {
-    key   = "PatchGroup"
+    key   = "Patch Group"
     value = "None"
   }
-  description = "Optional bastion host patch groups tag"
+  description = "Optional bastion host patch group tag"
   type = object({
     key   = string
     value = string


### PR DESCRIPTION
I am hard coding the patch group tag with a default of "None" because we're not able to use dynamic tags here, and dynamically adding in a key name is messy and doesn't seem worth it based on the syntax you have to use. Hopefully they will add dynamic tags for this resource in the future. 

I have now confirmed that the tag name with a space in it works for the ECS clusters, thats why it took so long to get this PR up because I wanted to be sure. 

The bastion instance currently does not have any IAM role, which it needs to have in order to add the SSM policy attachment in our handytrac repo, so I'm adding an empty role here. This should not affect anyone else negatively, because I see there are some roles currently in one of our accounts that are empty and that seems to be okay. 