### PR TITLE
Add eip/route53 to bastion host if only 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,20 @@ module "networking" {
   bastion_key_name       = "name-of-your-bastion-pem"
   utility_subnet_cidr    = "155.0.0.0/16"
   vpc_addl_address_space = ["172.0.0.0/16"]
+
+  bastion_route53 = {
+    zone = {
+      name = "7factor.io"
+    }
+    record = {
+      name = "db.7factor.io"
+    }
+  }
 }
 ```
+
+### EIP and Route53 behavior
+If `bastion_count = 1` and `bastion_route53` is provided, the bastion will be assigned an EIP and a Route53 record will be created for it. If `bastion_count > 1` or `bastion_route53` is not provided, the bastion will not be assigned an EIP and no Route53 record will be created for it.
 
 ## Migrating to Terraform Registry version
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,9 @@ module "networking" {
 ```
 
 ### EIP and Route53 behavior
-If `bastion_count = 1` and `bastion_route53` is provided, the bastion will be assigned an EIP and a Route53 record will be created for it. If `bastion_count > 1` or `bastion_route53` is not provided, the bastion will not be assigned an EIP and no Route53 record will be created for it.
+If `bastion_count = 1` and `bastion_route53` is provided, the bastion will be assigned an EIP and a Route53 record will be created for it. 
+If `bastion_count > 1` or `bastion_route53` is not provided, the bastion will not be assigned an EIP and no Route53 record will be created for it.
+This will allow you to define an EIP and Route53 record for a single bastion, but not for a bastion autoscaling group.
 
 ## Migrating to Terraform Registry version
 

--- a/ec2.tf
+++ b/ec2.tf
@@ -58,7 +58,7 @@ resource "aws_route53_record" "eip_a_record" {
   count   = local.enable_single_bastion_eip ? 1 : 0
   type    = "A"
   name    = var.bastion_route53.record.name
-  zone_id = data.aws_route53_zone.root_zone.zone_id
+  zone_id = data.aws_route53_zone.root_zone[0].zone_id
   records = [aws_eip.single_bastion_eip[0].public_ip]
   ttl     = 300
 }

--- a/output.tf
+++ b/output.tf
@@ -39,13 +39,13 @@ output "bastion_host_ids" {
 }
 
 output "bastion_host_public_ips" {
-  value       = aws_instance.bastion_hosts.*.public_ip
+  value       = local.enable_single_bastion_eip ? [aws_eip.single_bastion_eip[0].public_ip] : aws_instance.bastion_hosts.*.public_ip
   description = "A list of public IP addresses for your bastion hosts."
 }
 
 output "bastion_host_private_ips" {
-  value       = aws_instance.bastion_hosts.*.private_ip
-  description = "A list of pribate IP addresses for your bastion hosts."
+  value       = local.enable_single_bastion_eip ? [aws_eip.single_bastion_eip[0].private_ip] : aws_instance.bastion_hosts.*.private_ip
+  description = "A list of private IP addresses for your bastion hosts."
 }
 
 output "vpc_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -89,3 +89,16 @@ variable "enable_dns_support" {
   type        = bool
   default     = true
 }
+
+variable "bastion_route53" {
+  description = "Route53 configuration."
+  type = object({
+    zone = object({
+      name = string
+    })
+    record = object({
+      name = string
+    })
+  })
+  default = null
+}


### PR DESCRIPTION
If only 1 bastion host and bastion_route53 data is defined
- Add EIP to bastion host
- Add Route53 that point to EIP

Based on dumptruckman's suggestion on issue #17 